### PR TITLE
Add RPM packaging SPEC for throughputd

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,70 @@ Note: the table name can be altered with the -a option
 
 ## Compilation and Installation
 The current dependencies of throuputd are gcc, libpcap, libpthread, and libsqlite3. After these libraries are installed on the system you can simply run `make` to build the binary. There is also a `make install` target to install the binary onto the system.
+
+### Building Distribution Packages
+Sample distribution packaging scripts for RPM based distributions (Fedora, CentOS/Red Hat Enterprise Linux, Mageia, and openSUSE) and Debian based distributions (Debian and Ubuntu) are provided. These can be used to generate native packages for supported Linux distributions.
+
+#### RPM based distributions
+
+1. Install `rpm-build` and the dependencies.
+
+   * Fedora/CentOS/RHEL install commands:
+
+      * `sudo dnf install rpm-build sqlite-devel libpcap-devel @development-tools` (Fedora 22 and newer)
+
+      * `sudo yum install rpm-build sqlite-devel libpcap-devel @development-tools` (CentOS/RHEL + Fedora 21 and older)
+
+   * Mageia install commands:
+
+      * `sudo urpmi rpm-build sqlite3-devel pcap-devel gcc` (Mageia 5)
+
+      * `sudo dnf install rpm-build sqlite3-devel pcap-devel gcc` (Mageia 6)
+
+   * openSUSE install commands:
+
+      * `sudo zypper install rpm-build sqlite-devel libpcap-devel gcc`
+
+2. Download the [tarball from GitHub](https://github.com/datto/throughputd/archive/master.tar.gz).
+
+3. Construct your build root by running `mkdir -p ~/rpmbuild/{SOURCES,SPECS,SRPMS,RPMS,BUILD,BUILDROOT}`
+
+4. Place the downloaded tarball into `~/rpmbuild/SOURCES`.
+
+5. Extract the spec file (`throughputd.spec`) to `~/rpmbuild/SPECS`.
+
+6. Change into `~/rpmbuild/SPECS` and run `rpmbuild -bb throughputd.spec` to generate the RPM.
+
+7. Retrieve the built throughputd RPM from `~/rpmbuild/RPMS/<arch>` (where `<arch>` is your computer's architecture)
+
+#### Debian based distributions
+
+1. Install `build-essential` and the dependencies by running `sudo apt-get install build-essential libsqlite3-dev libpcap0.8-dev`
+
+2. Download the [tarball from GitHub](https://github.com/datto/throughputd/archive/master.tar.gz).
+
+3. Extract the tarball and change into the directory (typically `throughputd-master`) and run `dpkg-buildpackage -b -us -uc`
+
+4. Retrieve the built throughputd Debian package
+
+### Installing Distribution Packages
+
+After building your package, you can install it by doing the following:
+
+#### RPM based distributions
+
+Fedora 22+/Mageia 6+: `sudo dnf install </path/to/built/rpm>`
+
+Fedora 21 and older/CentOS/RHEL: `sudo yum install </path/to/built/rpm>`
+
+Mageia 5: `sudo urpmi </path/to/built/rpm>`
+
+openSUSE: `sudo zypper install </path/to/built/rpm>`
+
+#### Debian based distributions
+
+Run the following commands:
+
+1. `sudo dpkg -i </path/to/built/deb>`
+
+2. If it complains about missing dependencies, then run `sudo apt-get install -f`

--- a/throughputd.spec
+++ b/throughputd.spec
@@ -1,0 +1,98 @@
+Name:		throughputd
+Version:	1.1.0
+Release:	1%{?dist}
+Summary:	A network traffic monitoring tool
+
+# Mageia requires the Group to be specified
+%if 0%{?mageia}
+Group:		Networking/Other
+%endif
+
+# SUSE requires the Group to be specified
+%if 0%{?suse_version}
+Group:		Productivity/Networking/Other
+%endif
+
+%if 0%{?suse_version}
+# SUSE uses a different license label format, based on SPDX
+License:	GPL-2.0
+%else
+License:	GPLv2
+%endif
+
+URL:		https://github.com/datto/throughputd
+
+# The Source has the name that GitHub will send the tarball to the browser as at the end
+Source0:	https://github.com/datto/throughputd/archive/master.tar.gz#/%{name}-master.tar.gz
+
+BuildRequires:	pkgconfig(sqlite3)
+
+# libpcap doesn't provide pkgconfig file, so we must use package name
+# This name is supported across Fedora, SUSE, and Mageia
+BuildRequires:	libpcap-devel
+
+# Provides the systemd macros
+%if 0%{?mageia}
+BuildRequires:	systemd-devel
+%else
+BuildRequires:	systemd-units
+%endif
+
+# Scriptlet requirements
+Requires(post):     systemd
+Requires(preun):    systemd
+Requires(postun):   systemd
+
+%description
+Throughputd is a network traffic monitoring utility.
+It listens for IPv4 and IPv6 traffic and maintains records
+of how much data (in bytes) is going to and from each IP.
+This data is accumulated and saved to an SQLite database at
+a set interval.
+
+%prep
+%setup -q -n %{name}-master
+
+
+%build
+make %{?_smp_mflags}
+
+
+%install
+%make_install PREFIX=%{_prefix}
+
+# Install systemd files
+mkdir -p %{buildroot}%{_sysconfdir}/default
+mkdir -p %{buildroot}%{_unitdir}
+install -pm 0644 debian/%{name}.default %{buildroot}%{_sysconfdir}/default/%{name} 
+install -pm 0444 debian/%{name}.service %{buildroot}%{_unitdir}/%{name}.service
+
+# For ghost file data, so that RPM will remove them if they exist.
+# These empty files will not actually be installed.
+mkdir -p %{buildroot}%{_var}/lib/%{name}
+touch %{buildroot}%{_var}/lib/%{name}/%{name}.sqlite
+
+%files
+%{_bindir}/%{name}
+%{_unitdir}/%{name}.service
+%config(noreplace) %{_sysconfdir}/default/%{name}
+%ghost %{_var}/lib/%{name}
+%if 0%{?fedora} || 0%{?rhel} || 0%{?mageia}
+%license COPYING
+%else
+%doc COPYING
+%endif
+%doc README.md
+
+%post
+%systemd_post %{name}.service
+
+%preun
+%systemd_preun %{name}.service
+
+%postun
+%systemd_postun_with_restart %{name}.service
+
+%changelog
+* Mon Dec  7 2015 Neal Gompa <ngompa@datto.com> - 1.1.0-1
+- Initial packaging


### PR DESCRIPTION
This pull request adds the SPEC file for RPM packaging to build throughputd on Fedora, CentOS/RHEL, Mageia, and openSUSE.
