### PR TITLE
Add systemd macros BR for SUSE and make README.md more consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,17 +42,17 @@ Sample distribution packaging scripts for RPM based distributions (Fedora, CentO
 
    * Fedora/CentOS/RHEL install commands:
 
-      * `sudo dnf install rpm-build sqlite-devel libpcap-devel @development-tools` (Fedora 22 and newer)
+      * Fedora 22 and newer: `sudo dnf install rpm-build sqlite-devel libpcap-devel @development-tools`
 
-      * `sudo yum install rpm-build sqlite-devel libpcap-devel @development-tools` (CentOS/RHEL + Fedora 21 and older)
+      * CentOS/RHEL + Fedora 21 and older: `sudo yum install rpm-build sqlite-devel libpcap-devel @development-tools`
 
    * Mageia install commands:
 
-      * `sudo urpmi rpm-build sqlite3-devel pcap-devel gcc` (Mageia 5)
+      * Mageia 5: `sudo urpmi rpm-build sqlite3-devel pcap-devel gcc`
 
-      * `sudo dnf install rpm-build sqlite3-devel pcap-devel gcc` (Mageia 6)
+      * Mageia 6: `sudo dnf install rpm-build sqlite3-devel pcap-devel gcc`
 
-   * openSUSE install commands:
+   * openSUSE Tumbleweed install commands:
 
       * `sudo zypper install rpm-build sqlite-devel libpcap-devel gcc`
 
@@ -90,7 +90,7 @@ Fedora 21 and older/CentOS/RHEL: `sudo yum install </path/to/built/rpm>`
 
 Mageia 5: `sudo urpmi </path/to/built/rpm>`
 
-openSUSE: `sudo zypper install </path/to/built/rpm>`
+openSUSE Tumbleweed: `sudo zypper install </path/to/built/rpm>`
 
 #### Debian based distributions
 

--- a/throughputd.spec
+++ b/throughputd.spec
@@ -32,10 +32,14 @@ BuildRequires:	pkgconfig(sqlite3)
 BuildRequires:	libpcap-devel
 
 # Provides the systemd macros
+%if 0%{?suse_version}
+BuildRequires: systemd-rpm-macros
+%else
 %if 0%{?mageia}
 BuildRequires:	systemd-devel
 %else
 BuildRequires:	systemd-units
+%endif
 %endif
 
 # Scriptlet requirements
@@ -72,6 +76,7 @@ install -pm 0444 debian/%{name}.service %{buildroot}%{_unitdir}/%{name}.service
 mkdir -p %{buildroot}%{_var}/lib/%{name}
 touch %{buildroot}%{_var}/lib/%{name}/%{name}.sqlite
 
+
 %files
 %{_bindir}/%{name}
 %{_unitdir}/%{name}.service
@@ -84,14 +89,18 @@ touch %{buildroot}%{_var}/lib/%{name}/%{name}.sqlite
 %endif
 %doc README.md
 
+
 %post
 %systemd_post %{name}.service
+
 
 %preun
 %systemd_preun %{name}.service
 
+
 %postun
 %systemd_postun_with_restart %{name}.service
+
 
 %changelog
 * Mon Dec  7 2015 Neal Gompa <ngompa@datto.com> - 1.1.0-1


### PR DESCRIPTION
The systemd macros package for SUSE required for the scriptlet macros wasn't included previously, so now it is. Also, it's now clear that openSUSE Tumbleweed is a supported build environment with the spec.
